### PR TITLE
GCC5 fixes

### DIFF
--- a/cmake/RegexChecks.cmake
+++ b/cmake/RegexChecks.cmake
@@ -30,6 +30,16 @@ int main() {
   if (${namespace}_match(fail, bar)) return 11;
   if (${namespace}_match(fail, chk)) return 12;
 
+  // Checks for broken support in GCC 4.9 and 5.1
+  ${namespace} range1(\"^[a-z0-9][a-z0-9-]*\$\", ${namespace}::extended);
+  ${namespace} range2(\"^[a-z0-9][-a-z0-9]*\$\", ${namespace}::extended);
+  if (!${namespace}_match(test, range1)) return 13;
+  if (!${namespace}_match(test, range2)) return 14;
+  if (!${namespace}_match(\"a-\", range1)) return 15;
+  if (!${namespace}_match(\"a-\", range2)) return 16;
+  if (${namespace}_match(\"-a\", range1)) return 17;
+  if (${namespace}_match(\"-a\", range2)) return 18;
+
   return 0;
 }"
 ${outvar})

--- a/test/schroot/keyfile.cc
+++ b/test/schroot/keyfile.cc
@@ -69,7 +69,7 @@ TEST_F(Keyfile, ConstructFile)
 TEST_F(Keyfile, ConstructStream)
 {
   std::ifstream strm(TESTDATADIR "/keyfile.ex1");
-  ASSERT_TRUE(strm);
+  ASSERT_TRUE(!!strm);
   schroot::keyfile k;
   ASSERT_NO_THROW(schroot::keyfile_reader(k, strm));
 }

--- a/test/schroot/regex.cc
+++ b/test/schroot/regex.cc
@@ -59,6 +59,22 @@ TEST(Regex, Match)
   ASSERT_FALSE(schroot::regex_search(":fail:", r));
 }
 
+TEST(Regex, MatchBracket1)
+{
+  schroot::regex r("^[a-z0-9][a-z0-9-]*$");
+  ASSERT_TRUE(schroot::regex_search("foobar", r));
+  ASSERT_TRUE(schroot::regex_search("a-", r));
+  ASSERT_FALSE(schroot::regex_search("-a", r));
+}
+
+TEST(Regex, MatchBracket2)
+{
+  schroot::regex r("^[a-z0-9][-a-z0-9]*$");
+  ASSERT_TRUE(schroot::regex_search("foobar", r));
+  ASSERT_TRUE(schroot::regex_search("a-", r));
+  ASSERT_FALSE(schroot::regex_search("-a", r));
+}
+
 TEST(Regex, StreamInputFail)
 {
   schroot::regex r;


### PR DESCRIPTION
- Add extra checks for both cmake and unit tests to pick up broken regex support in libstdc++ and so correctly fall back to boost_regex rather than use a broken implementation.
- Correct keyfile test to check for stream validity; newer libstdc++ is now more standards conformant