### PR TITLE
GCC5 fixes (1.6)

### DIFF
--- a/cmake/regex-checks.cmake
+++ b/cmake/regex-checks.cmake
@@ -30,6 +30,16 @@ int main() {
   if (${namespace}_match(fail, bar)) return 11;
   if (${namespace}_match(fail, chk)) return 12;
 
+  // Checks for broken support in GCC 4.9 and 5.1
+  ${namespace} range1(\"^[a-z0-9][a-z0-9-]*\$\", ${namespace}::extended);
+  ${namespace} range2(\"^[a-z0-9][-a-z0-9]*\$\", ${namespace}::extended);
+  if (!${namespace}_match(test, range1)) return 13;
+  if (!${namespace}_match(test, range2)) return 14;
+  if (!${namespace}_match(\"a-\", range1)) return 15;
+  if (!${namespace}_match(\"a-\", range2)) return 16;
+  if (${namespace}_match(\"-a\", range1)) return 17;
+  if (${namespace}_match(\"-a\", range2)) return 18;
+
   return 0;
 }"
 ${outvar})

--- a/test/sbuild-keyfile.cc
+++ b/test/sbuild-keyfile.cc
@@ -93,7 +93,7 @@ public:
   test_construction_stream()
   {
     std::ifstream strm(TESTDATADIR "/keyfile.ex1");
-    CPPUNIT_ASSERT(strm);
+    CPPUNIT_ASSERT(!!strm);
     sbuild::keyfile k(strm);
   }
 

--- a/test/sbuild-regex.cc
+++ b/test/sbuild-regex.cc
@@ -33,6 +33,8 @@ class test_regex : public TestCase
   CPPUNIT_TEST(test_output);
   CPPUNIT_TEST(test_input);
   CPPUNIT_TEST(test_match);
+  CPPUNIT_TEST(test_match_bracket1);
+  CPPUNIT_TEST(test_match_bracket2);
   CPPUNIT_TEST_EXCEPTION(test_input_fail, std::regex_error);
   CPPUNIT_TEST_SUITE_END();
 
@@ -85,6 +87,24 @@ public:
   {
     sbuild::regex r("^[^:/,.][^:/,]*$");
     sbuild::regex_search("foobar", r);
+  }
+
+  void
+  test_match_bracket1()
+  {
+    sbuild::regex r("^[a-z0-9][a-z0-9-]*$");
+    CPPUNIT_ASSERT(sbuild::regex_search("foobar", r));
+    CPPUNIT_ASSERT(sbuild::regex_search("a-", r));
+    CPPUNIT_ASSERT(!sbuild::regex_search("-a", r));
+  }
+
+  void
+  test_match_bracket2()
+  {
+    sbuild::regex r("^[a-z0-9][-a-z0-9]*$");
+    CPPUNIT_ASSERT(sbuild::regex_search("foobar", r));
+    CPPUNIT_ASSERT(sbuild::regex_search("a-", r));
+    CPPUNIT_ASSERT(!sbuild::regex_search("-a", r));
   }
 
   void


### PR DESCRIPTION
- Add extra checks for both cmake and unit tests to pick up broken regex support in libstdc++ and so correctly fall back to boost_regex rather than use a broken implementation.
- Correct keyfile test to check for stream validity; newer libstdc++ is now more standards conformant.