### PR TITLE
schroot: directory: Correct btrfs_snapshot copy constructor

### DIFF
--- a/lib/schroot/chroot/facet/directory.cc
+++ b/lib/schroot/chroot/facet/directory.cc
@@ -78,7 +78,7 @@ namespace schroot
       directory::directory (const btrfs_snapshot& rhs):
         facet(rhs),
         storage(rhs),
-        directory_(rhs.directory_)
+        directory_()
       {
         set_directory(rhs.get_source_subvolume());
       }


### PR DESCRIPTION
Fix broken directory initialisation.